### PR TITLE
Faster rotation

### DIFF
--- a/orbcore/orbits.go
+++ b/orbcore/orbits.go
@@ -75,13 +75,13 @@ func OrbitToVector(orbit *Orbit) (mat.Vector, mat.Vector) {
 
 	r, v := OrbitToVecPerifocal(orbit)
 
-	/*
-		//TODO: Fix this and put it back in some day.
-		rot := QuickerRotationMatrixForOrbit(orbit.ArgumentOfPerihelion, orbit.InclinationToTheEcliptic, orbit.LongitudeOfTheAscendingNode)
 
-		r.MulVec(rot, r)
-		v.MulVec(rot, v)
-	*/
+	//TODO: Fix this and put it back in some day.
+	rot := QuickerRotationMatrixForOrbit(orbit.LongitudeOfTheAscendingNode, orbit.InclinationToTheEcliptic, orbit.ArgumentOfPerihelion)
+
+	r.MulVec(rot, r)
+	v.MulVec(rot, v)
+	/*
 	r = Rotate(r, orbit.ArgumentOfPerihelion, AxisZ)
 	r = Rotate(r, orbit.InclinationToTheEcliptic, AxisX)
 	r = Rotate(r, orbit.LongitudeOfTheAscendingNode, AxisZ)
@@ -89,7 +89,7 @@ func OrbitToVector(orbit *Orbit) (mat.Vector, mat.Vector) {
 	v = Rotate(v, orbit.ArgumentOfPerihelion, AxisZ)
 	v = Rotate(v, orbit.InclinationToTheEcliptic, AxisX)
 	v = Rotate(v, orbit.LongitudeOfTheAscendingNode, AxisZ)
-
+*/
 	return r, v
 }
 

--- a/orbcore/orbits.go
+++ b/orbcore/orbits.go
@@ -75,21 +75,11 @@ func OrbitToVector(orbit *Orbit) (mat.Vector, mat.Vector) {
 
 	r, v := OrbitToVecPerifocal(orbit)
 
-
-	//TODO: Fix this and put it back in some day.
 	rot := QuickerRotationMatrixForOrbit(orbit.LongitudeOfTheAscendingNode, orbit.InclinationToTheEcliptic, orbit.ArgumentOfPerihelion)
 
 	r.MulVec(rot, r)
 	v.MulVec(rot, v)
-	/*
-	r = Rotate(r, orbit.ArgumentOfPerihelion, AxisZ)
-	r = Rotate(r, orbit.InclinationToTheEcliptic, AxisX)
-	r = Rotate(r, orbit.LongitudeOfTheAscendingNode, AxisZ)
 
-	v = Rotate(v, orbit.ArgumentOfPerihelion, AxisZ)
-	v = Rotate(v, orbit.InclinationToTheEcliptic, AxisX)
-	v = Rotate(v, orbit.LongitudeOfTheAscendingNode, AxisZ)
-*/
 	return r, v
 }
 

--- a/orbcore/orbits_test.go
+++ b/orbcore/orbits_test.go
@@ -25,3 +25,26 @@ func TestOrbitalPeriod(t *testing.T) {
 		t.Errorf("Got %v expected %v", r, expected)
 	}
 }
+
+
+func BenchmarkOrbitToVector(b *testing.B){
+
+	ceres := Orbit{
+		ID:                          "1", // Ceres
+		ParentGrav:                  132712442099.00002,
+		Epoch:                       time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC), // todo: real epoch times.
+		MeanAnomalyEpoch:            6.147582300011738,
+		ArgumentOfPerihelion:        1.2761023695175595,
+		LongitudeOfTheAscendingNode: 1.4016725260132445,
+		InclinationToTheEcliptic:    0.1848916288429445,
+		OrbitalEccentricity:         0.0755347,
+		SemimajorAxis:               4.1394459238740003e+08,
+	}
+
+	for n := 0; n < b.N; n++ {
+		r, v := OrbitToVector(&ceres)
+		if r == nil || v == nil {
+			b.Fatal("Got an invalid result")
+		}
+	}
+}


### PR DESCRIPTION
Fix the problem with the faster rotation matrix code. I was the parameters in the wrong order.
This new code is significantly faster.

original: BenchmarkOrbitToVector-4   	  200000	     10733 ns/op
now:  BenchmarkOrbitToVector-4   	 1000000	      1755 ns/op